### PR TITLE
Allow paging to be optionally disabled

### DIFF
--- a/branchrestrictions.go
+++ b/branchrestrictions.go
@@ -17,7 +17,7 @@ type BranchRestrictions struct {
 
 func (b *BranchRestrictions) Gets(bo *BranchRestrictionsOptions) (interface{}, error) {
 	urlStr := b.c.requestUrl("/repositories/%s/%s/branch-restrictions", bo.Owner, bo.RepoSlug)
-	return b.c.execute("GET", urlStr, "")
+	return b.c.executePaginated("GET", urlStr, "")
 }
 
 func (b *BranchRestrictions) Create(bo *BranchRestrictionsOptions) (*BranchRestrictions, error) {

--- a/commits.go
+++ b/commits.go
@@ -1,8 +1,8 @@
 package bitbucket
 
 import (
-	"net/url"
 	"encoding/json"
+	"net/url"
 )
 
 type Commits struct {
@@ -12,7 +12,7 @@ type Commits struct {
 func (cm *Commits) GetCommits(cmo *CommitsOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commits/%s", cmo.Owner, cmo.RepoSlug, cmo.Branchortag)
 	urlStr += cm.buildCommitsQuery(cmo.Include, cmo.Exclude)
-	return cm.c.execute("GET", urlStr, "")
+	return cm.c.executePaginated("GET", urlStr, "")
 }
 
 func (cm *Commits) GetCommit(cmo *CommitsOptions) (interface{}, error) {
@@ -22,7 +22,7 @@ func (cm *Commits) GetCommit(cmo *CommitsOptions) (interface{}, error) {
 
 func (cm *Commits) GetCommitComments(cmo *CommitsOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/comments", cmo.Owner, cmo.RepoSlug, cmo.Revision)
-	return cm.c.execute("DELETE", urlStr, "")
+	return cm.c.executePaginated("GET", urlStr, "")
 }
 
 func (cm *Commits) GetCommitComment(cmo *CommitsOptions) (interface{}, error) {
@@ -32,7 +32,7 @@ func (cm *Commits) GetCommitComment(cmo *CommitsOptions) (interface{}, error) {
 
 func (cm *Commits) GetCommitStatuses(cmo *CommitsOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses", cmo.Owner, cmo.RepoSlug, cmo.Revision)
-	return cm.c.execute("GET", urlStr, "")
+	return cm.c.executePaginated("GET", urlStr, "")
 }
 
 func (cm *Commits) GetCommitStatus(cmo *CommitsOptions, commitStatusKey string) (interface{}, error) {
@@ -50,7 +50,6 @@ func (cm *Commits) RemoveApprove(cmo *CommitsOptions) (interface{}, error) {
 	return cm.c.execute("DELETE", urlStr, "")
 }
 
-
 func (cm *Commits) CreateCommitStatus(cmo *CommitsOptions, cso *CommitStatusOptions) (interface{}, error) {
 	urlStr := cm.c.requestUrl("/repositories/%s/%s/commit/%s/statuses/build", cmo.Owner, cmo.RepoSlug, cmo.Revision)
 	data, err := json.Marshal(cso)
@@ -59,7 +58,6 @@ func (cm *Commits) CreateCommitStatus(cmo *CommitsOptions, cso *CommitStatusOpti
 	}
 	return cm.c.execute("POST", urlStr, string(data))
 }
-
 
 func (cm *Commits) buildCommitsQuery(include, exclude string) string {
 

--- a/downloads.go
+++ b/downloads.go
@@ -11,5 +11,5 @@ func (dl *Downloads) Create(do *DownloadsOptions) (interface{}, error) {
 
 func (dl *Downloads) List(do *DownloadsOptions) (interface{}, error) {
 	urlStr := dl.c.requestUrl("/repositories/%s/%s/downloads", do.Owner, do.RepoSlug)
-	return dl.c.execute("GET", urlStr, "")
+	return dl.c.executePaginated("GET", urlStr, "")
 }

--- a/issues.go
+++ b/issues.go
@@ -37,7 +37,7 @@ func (p *Issues) Gets(io *IssuesOptions) (interface{}, error) {
 		url.RawQuery = query.Encode()
 	}
 
-	return p.c.execute("GET", url.String(), "")
+	return p.c.executePaginated("GET", url.String(), "")
 }
 
 func (p *Issues) Get(io *IssuesOptions) (interface{}, error) {

--- a/pipelines.go
+++ b/pipelines.go
@@ -46,7 +46,7 @@ func (p *Pipelines) List(po *PipelinesOptions) (interface{}, error) {
 		urlStr = parsed.String()
 	}
 
-	return p.c.execute("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "")
 }
 
 func (p *Pipelines) Get(po *PipelinesOptions) (interface{}, error) {
@@ -90,7 +90,7 @@ func (p *Pipelines) ListSteps(po *PipelinesOptions) (interface{}, error) {
 		urlStr = parsed.String()
 	}
 
-	return p.c.execute("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "")
 }
 
 func (p *Pipelines) GetStep(po *PipelinesOptions) (interface{}, error) {

--- a/pullrequests.go
+++ b/pullrequests.go
@@ -65,7 +65,7 @@ func (p *PullRequests) Gets(po *PullRequestsOptions) (interface{}, error) {
 		urlStr = parsed.String()
 	}
 
-	return p.c.execute("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "")
 }
 
 func (p *PullRequests) Get(po *PullRequestsOptions) (interface{}, error) {
@@ -75,7 +75,7 @@ func (p *PullRequests) Get(po *PullRequestsOptions) (interface{}, error) {
 
 func (p *PullRequests) Activities(po *PullRequestsOptions) (interface{}, error) {
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/activity"
-	return p.c.execute("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "")
 }
 
 func (p *PullRequests) Activity(po *PullRequestsOptions) (interface{}, error) {
@@ -85,7 +85,7 @@ func (p *PullRequests) Activity(po *PullRequestsOptions) (interface{}, error) {
 
 func (p *PullRequests) Commits(po *PullRequestsOptions) (interface{}, error) {
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/commits"
-	return p.c.execute("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "")
 }
 
 func (p *PullRequests) Patch(po *PullRequestsOptions) (interface{}, error) {
@@ -158,7 +158,7 @@ func (p *PullRequests) UpdateComment(co *PullRequestCommentOptions) (interface{}
 
 func (p *PullRequests) GetComments(po *PullRequestsOptions) (interface{}, error) {
 	urlStr := p.c.GetApiBaseURL() + "/repositories/" + po.Owner + "/" + po.RepoSlug + "/pullrequests/" + po.ID + "/comments/"
-	return p.c.execute("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "")
 }
 
 func (p *PullRequests) GetComment(po *PullRequestsOptions) (interface{}, error) {
@@ -189,7 +189,7 @@ func (p *PullRequests) Statuses(po *PullRequestsOptions) (interface{}, error) {
 		parsed.RawQuery = query.Encode()
 		urlStr = parsed.String()
 	}
-	return p.c.execute("GET", urlStr, "")
+	return p.c.executePaginated("GET", urlStr, "")
 }
 
 func (p *PullRequests) buildPullRequestBody(po *PullRequestsOptions) (string, error) {

--- a/repositories.go
+++ b/repositories.go
@@ -25,11 +25,10 @@ type Repositories struct {
 }
 
 type RepositoriesRes struct {
-	Page     int32
-	Pagelen  int32
-	MaxDepth int32
-	Size     int32
-	Items    []Repository
+	Page    int32
+	Pagelen int32
+	Size    int32
+	Items   []Repository
 }
 
 func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (*RepositoriesRes, error) {
@@ -41,7 +40,7 @@ func (r *Repositories) ListForAccount(ro *RepositoriesOptions) (*RepositoriesRes
 	if ro.Role != "" {
 		urlStr += "?role=" + ro.Role
 	}
-	repos, err := r.c.execute("GET", urlStr, "")
+	repos, err := r.c.executePaginated("GET", urlStr, "")
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +54,7 @@ func (r *Repositories) ListForTeam(ro *RepositoriesOptions) (*RepositoriesRes, e
 
 func (r *Repositories) ListPublic() (*RepositoriesRes, error) {
 	urlStr := r.c.requestUrl("/repositories/")
-	repos, err := r.c.execute("GET", urlStr, "")
+	repos, err := r.c.executePaginated("GET", urlStr, "")
 	if err != nil {
 		return nil, err
 	}
@@ -87,21 +86,16 @@ func decodeRepositories(reposResponse interface{}) (*RepositoriesRes, error) {
 	if !ok {
 		pagelen = 0
 	}
-	max_depth, ok := reposResponseMap["max_width"].(float64)
-	if !ok {
-		max_depth = 0
-	}
 	size, ok := reposResponseMap["size"].(float64)
 	if !ok {
 		size = 0
 	}
 
 	repositories := RepositoriesRes{
-		Page:     int32(page),
-		Pagelen:  int32(pagelen),
-		MaxDepth: int32(max_depth),
-		Size:     int32(size),
-		Items:    repos,
+		Page:    int32(page),
+		Pagelen: int32(pagelen),
+		Size:    int32(size),
+		Items:   repos,
 	}
 	return &repositories, nil
 }

--- a/webhooks.go
+++ b/webhooks.go
@@ -61,7 +61,7 @@ func (r *Webhooks) buildWebhooksBody(ro *WebhooksOptions) (string, error) {
 
 func (r *Webhooks) Gets(ro *WebhooksOptions) (interface{}, error) {
 	urlStr := r.c.requestUrl("/repositories/%s/%s/hooks/", ro.Owner, ro.RepoSlug)
-	return r.c.execute("GET", urlStr, "")
+	return r.c.executePaginated("GET", urlStr, "")
 }
 
 func (r *Webhooks) Create(ro *WebhooksOptions) (*Webhook, error) {

--- a/workspaces.go
+++ b/workspaces.go
@@ -45,7 +45,7 @@ type ProjectsRes struct {
 
 func (t *Permission) GetUserPermissions(organization, member string) (*Permission, error) {
 	urlStr := t.c.requestUrl("/workspaces/%s/permissions?q=user.nickname=\"%s\"", organization, member)
-	response, err := t.c.execute("GET", urlStr, "")
+	response, err := t.c.executePaginated("GET", urlStr, "")
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (t *Permission) GetUserPermissions(organization, member string) (*Permissio
 
 func (t *Permission) GetUserPermissionsByUuid(organization, member string) (*Permission, error) {
 	urlStr := t.c.requestUrl("/workspaces/%s/permissions?q=user.uuid=\"%s\"", organization, member)
-	response, err := t.c.execute("GET", urlStr, "")
+	response, err := t.c.executePaginated("GET", urlStr, "")
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (t *Permission) GetUserPermissionsByUuid(organization, member string) (*Per
 
 func (t *Workspace) List() (*WorkspaceList, error) {
 	urlStr := t.c.requestUrl("/workspaces")
-	response, err := t.c.execute("GET", urlStr, "")
+	response, err := t.c.executePaginated("GET", urlStr, "")
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (w *Workspace) Members(teamname string) (interface{}, error) {
 
 func (w *Workspace) Projects(teamname string) (*ProjectsRes, error) {
 	urlStr := w.c.requestUrl("/workspaces/%s/projects/", teamname)
-	response, err := w.c.execute("GET", urlStr, "")
+	response, err := w.c.executePaginated("GET", urlStr, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Added a new option, `DisableAutoPaging`. This defaults to false for backwards compatibility, but allows the behaviour of automatically requesting all pages of a paged response to be disabled.
- While doing this I split the `execute()` method into two versions - one that supports paging and another that doesn't. The reason I did this is that the previous version was adding the `pagelen` parameter for any paths containing `/repositories/`, but this breaks if you call `Repositories.ListForAccount()` with a role specified, in which case there's no trailing `/`. I figured it was better to be explicit about when to support paging or not.
- Moved the `max_depth` support out of the client and into `Repository.ListFiles()`, which is where it's actually supported. I noticed that `Repository.ListBranches()` also specifies the max depth. It doesn't look like this is actually supported by the API to me, but I didn't want to risk breaking it in case I'm wrong.
- Fixed a mistake in `GetCommitContents()` where it was using a `DELETE` instead of a `GET`.